### PR TITLE
Bugfix / input focus loss

### DIFF
--- a/src/App.test.tsx
+++ b/src/App.test.tsx
@@ -33,12 +33,19 @@ describe('App', () => {
     expect(screen.getByRole('textbox')).toHaveValue('react');
   });
 
-  it('changed input value', () => {
+  it('changed input value', async () => {
     setup();
-    const input = screen.getByRole('textbox');
-    expect(input).toHaveValue('react');
-    fireEvent.change(input, { target: { value: 'angular' } });
-    expect(input).toHaveValue('angular');
+    await waitFor(
+      () => {
+        const input = screen.getByRole('textbox');
+        expect(input).toHaveValue('react');
+        fireEvent.change(input, { target: { value: 'angular' } });
+        expect(input).toHaveValue('angular');
+      },
+      {
+        timeout: 2000,
+      }
+    );
   });
 
   it('renders error in the input', () => {
@@ -56,18 +63,11 @@ describe('App', () => {
     expect(screen.getByRole('table')).toBeInTheDocument();
   });
 
-  it('renders table body after initial request', async () => {
+  it('renders table body after initial request', () => {
     setup();
 
-    await waitFor(
-      () => {
-        const items = screen.getAllByRole('rowgroup');
-        expect(items).toHaveLength(2);
-        expect(items[1].children.length).toBe(25);
-      },
-      {
-        timeout: 3000,
-      }
-    );
+    const items = screen.getAllByRole('rowgroup');
+    expect(items).toHaveLength(2);
+    expect(items[1].children.length).toBe(25);
   });
 });

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -48,7 +48,6 @@ function App() {
 
   const handleInputChange = useCallback(
     (e: React.ChangeEvent<HTMLInputElement | HTMLTextAreaElement>) => {
-      if (loading) return;
       setSearchQuery(e.target.value);
 
       // validation of value
@@ -69,7 +68,7 @@ function App() {
       // fetch the new data with debounce function
       debouncedFetch(e.target.value);
     },
-    [debouncedFetch, inputError, loading]
+    [debouncedFetch, inputError]
   );
 
   useEffect(() => {
@@ -110,7 +109,7 @@ function App() {
           value={searchQuery}
           error={inputError}
           helperText={inputError ? 'Enter at least 3 characters' : ''}
-          onChange={handleInputChange}
+          onChange={loading ? undefined : handleInputChange}
         />
       </Box>
       {error ? (

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -48,6 +48,7 @@ function App() {
 
   const handleInputChange = useCallback(
     (e: React.ChangeEvent<HTMLInputElement | HTMLTextAreaElement>) => {
+      if (loading) return;
       setSearchQuery(e.target.value);
 
       // validation of value
@@ -68,7 +69,7 @@ function App() {
       // fetch the new data with debounce function
       debouncedFetch(e.target.value);
     },
-    [debouncedFetch, inputError]
+    [debouncedFetch, inputError, loading]
   );
 
   useEffect(() => {
@@ -109,7 +110,6 @@ function App() {
           value={searchQuery}
           error={inputError}
           helperText={inputError ? 'Enter at least 3 characters' : ''}
-          disabled={loading}
           onChange={handleInputChange}
         />
       </Box>


### PR DESCRIPTION
Description:

input looses the focus after fetching the data


Bug cause:

It seems like the cause of this bug is internal `<TextField />` component logic from materialUI that reset the `focus` after applying `disabled` styles. Component is still functionally focused, but the styles are not applied.


Solution:
- remove disabled prop
- edit `onChange` handler to do nothing if loading